### PR TITLE
Fix stemtag typo

### DIFF
--- a/data/scbi.dendroAll_2019.csv
+++ b/data/scbi.dendroAll_2019.csv
@@ -56,7 +56,7 @@
 20712,1,2019.15,2019,11,6,1,0,"litu",212,1.5,8.3,61.99,"","","alive","Cameron Dow, Kate Heneberry","Alyssa Terrell",2897,2897,NA,896.2,0,725,2,NA,1.45,NA,NA,NA,NA
 22004,1,2019.01,2019,3,28,1,0,"litu",217,11.4,1.7,144.12,"RE","","alive","Rebecca Banbury Morgan, Ian McGregor","Ian McGregor",3037,3037,NA,810,0,245,2,NA,1.3,NA,NA,NA,NA
 22004,1,2019.011,2019,4,4,1,0,"litu",217,11.4,1.7,12.92,"","","alive","Norbert Kunert, Ian McGregor","Ian McGregor",3037,3037,840,841,1,923,2,NA,1.4,NA,NA,NA,NA
-22004,2,2019.15,2019,11,6,1,0,"litu",217,11.4,1.7,25.29,"","","alive","Helen Bontrager, Zoi Paraskevopoulou","Alyssa Terrell",3037,3037,NA,841,0,923,2,NA,1.4,NA,NA,NA,NA
+22004,1,2019.15,2019,11,6,1,0,"litu",217,11.4,1.7,25.29,"","","alive","Helen Bontrager, Zoi Paraskevopoulou","Alyssa Terrell",3037,3037,NA,841,0,923,2,NA,1.4,NA,NA,NA,NA
 22041,1,2019.01,2019,3,28,1,0,"litu",217,1.8,19,38.22,"","","alive","Rebecca Banbury Morgan, Ian McGregor","Ian McGregor",3072,3072,NA,817,0,751,2,NA,1.32,NA,NA,NA,NA
 22041,1,2019.15,2019,11,6,1,0,"litu",217,1.8,19,48.07,"","","alive","Helen Bontrager, Zoi Paraskevopoulou","Alyssa Terrell",3072,3072,NA,817,0,751,2,NA,1.32,NA,NA,NA,NA
 22170,1,2019.01,2019,3,28,1,0,"litu",221,7.9,13.8,30.77,"","band adjusted","alive","Rebecca Banbury Morgan, Ian McGregor","Ian McGregor",3197,3197,NA,1128,1,979,2,NA,1.2,NA,NA,NA,NA


### PR DESCRIPTION
For tag 22004, stemID 3037, on 2019-11-06. Here is a reproducible example of the typo.

```r
library(tidyverse)
library(lubridate)
library(here)

# Dendroband data for these stemIDs
here("data/") %>%
  dir(pattern = "scbi.dendroAll", full.names = TRUE) %>%
  map_dfr(.f = read_csv, col_types = cols(dbh = col_double(), dendDiam = col_double())) %>%
  mutate(date = str_c(year, month, day, sep = "-") %>% ymd()) %>%
  select(tag, stemID, stemtag, sp, date) %>%
  filter(stemID == 3037) %>%
  arrange(stemID, date) 
```

|   tag| stemID| stemtag|sp   |date       |
|-----:|------:|-------:|:----|:----------|
| 22004|   3037|       1|litu |2011-03-24 |
| 22004|   3037|       1|litu |2011-12-15 |
| 22004|   3037|       1|litu |2012-03-15 |
| 22004|   3037|       1|litu |2012-11-29 |
| 22004|   3037|       1|litu |2013-03-19 |
| 22004|   3037|       1|litu |2013-10-29 |
| 22004|   3037|       1|litu |2014-03-24 |
| 22004|   3037|       1|litu |2014-10-27 |
| 22004|   3037|       1|litu |2015-03-24 |
| 22004|   3037|       1|litu |2015-11-02 |
| 22004|   3037|       1|litu |2016-04-06 |
| 22004|   3037|       1|litu |2016-11-10 |
| 22004|   3037|       1|litu |2017-04-18 |
| 22004|   3037|       1|litu |2017-11-14 |
| 22004|   3037|       1|litu |2018-03-09 |
| 22004|   3037|       1|litu |2018-11-08 |
| 22004|   3037|       1|litu |2019-03-28 |
| 22004|   3037|       1|litu |2019-04-04 |
| 22004|   3037|       2|litu |2019-11-06 |
| 22004|   3037|       1|litu |2020-03-11 |